### PR TITLE
Add example build for Alpine Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,10 @@ orbs:
           docker_image:
             description: Repotag for the Docker image in which to run the example
             type: string
+          requires_docker:
+            description: Does the job require the ability to build and run containers?
+            type: boolean
+            default: false
         executor:
             name: cloudsmith_executor
             docker_image: <<parameters.docker_image>>
@@ -18,8 +22,11 @@ orbs:
         steps:
           - checkout:
               path: ~/repo
-          - setup_remote_docker:
-              docker_layer_caching: true
+          - when:
+              condition: <<parameters.requires_docker>>
+              steps:
+                - setup_remote_docker:
+                    docker_layer_caching: true
           - run:
               name: Prepare build environment
               command: |
@@ -48,6 +55,11 @@ orbs:
 workflows:
   commit:
     jobs:
+      - cloudsmith_examples/run:
+          name: alpine-cli
+          example_name: alpine-cli
+          docker_image: circleci/python:3.7.2
+          requires_docker: true
       - cloudsmith_examples/run:
           name: composer-cli
           example_name: composer-cli

--- a/examples/alpine-cli/Dockerfile
+++ b/examples/alpine-cli/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.9.2
+
+RUN apk add alpine-sdk
+
+RUN adduser -S circleci
+RUN addgroup circleci abuild
+RUN addgroup circleci wheel
+RUN mkdir -p /var/cache/distfiles
+RUN chmod a+w /var/cache/distfiles
+RUN sed -e 's/# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' -i /etc/sudoers
+
+WORKDIR /usr/build
+COPY . .
+
+RUN chown -R circleci .
+USER circleci

--- a/examples/alpine-cli/build.sh
+++ b/examples/alpine-cli/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eou pipefail
+
+# NOTE: Since CircleCI don't provide convenience images based on Alpine we have
+# to build one ourselves in which to run the build. This adds an extra level of
+# indirection that isn't great, but it works. In future we can build out own
+# base image and use that directly with Circle.
+docker build -t alpine-example-build .
+
+
+# build .apk for distribution
+function build_script {
+    USAGE='set -eou pipefail
+
+    cd "src/"
+
+    abuild-keygen -a -i -n
+    abuild checksum
+    abuild -r'
+
+    echo "$USAGE"
+}
+
+build_script | docker run -i --name build-$BUILD_NUMBER alpine-example-build sh
+
+# since we build inside a container we need to explicitly copy the artifacts out
+# after building
+docker cp build-$BUILD_NUMBER:/home/circleci/packages/build/x86_64/ .

--- a/examples/alpine-cli/deploy.sh
+++ b/examples/alpine-cli/deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eou pipefail
+
+
+# publish apk using the cloudsmith CLI
+cloudsmith push alpine $CLOUDSMITH_REPOSITORY/alpine/v3.9 \
+    x86_64/cloudsmith-alpine-example-1.0.$BUILD_NUMBER-r0.apk

--- a/examples/alpine-cli/prepare.sh
+++ b/examples/alpine-cli/prepare.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eou pipefail
+
+
+# install the cloudsmith CLI
+pip install --user cloudsmith-cli
+
+# replace "__EXAMPLE_VERSION__" with real version number as required
+grep -rl __EXAMPLE_VERSION__ src/ | xargs sed -i "s/__EXAMPLE_VERSION__/1.0.$BUILD_NUMBER/g"

--- a/examples/alpine-cli/src/APKBUILD
+++ b/examples/alpine-cli/src/APKBUILD
@@ -1,0 +1,16 @@
+# Contributor: Cloudsmith <support@cloudsmith.io>
+# Maintainer: Cloudsmith <support@cloudsmith.io>
+pkgname=cloudsmith-alpine-example
+pkgver=__EXAMPLE_VERSION__
+pkgrel=0
+pkgdesc="Be Awesome. Automate Everything."
+url="https://github.com/cloudsmith-io/cloudsmith-examples"
+arch="all"
+license="Apache-2.0"
+source="cloudsmith"
+builddir="$srcdir/"
+
+package() {
+	cd "$builddir"
+	install -Dm755 cloudsmith "$pkgdir"/usr/bin/cloudsmith
+}

--- a/examples/alpine-cli/src/cloudsmith
+++ b/examples/alpine-cli/src/cloudsmith
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Be Awesome. Automate Everything."


### PR DESCRIPTION
This PR adds a new example for Alpine Linux. Unfortunately CircleCi don't provide convenience images based on Alpine Linux so we have to build our own. In future we can probably build an Alpine build image out-of-band and use that instead 🤷‍♂️ 

Fixes #5 