### PR TITLE
Run install examples if present

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,11 @@ orbs:
               command: |
                 test -f deploy.sh || exit 0
                 ./deploy.sh
+          - run:
+              name: Install package from Cloudsmith
+              command: |
+                test -f install.sh || exit 0
+                ./install.sh
     executors:
       cloudsmith_executor:
         docker:


### PR DESCRIPTION
If an example contains an `install.sh` it will be run after the package is published to Cloudsmith.

This PR is mostly prep for language-specific examples to follow.